### PR TITLE
Small Correction of mutation (popSize) reqs

### DIFF
--- a/R/EvolutionStrategy.int.R
+++ b/R/EvolutionStrategy.int.R
@@ -82,7 +82,7 @@ EvolutionStrategy.int <- function(genomeLen, codonMin, codonMax,
     
     ############################################################################
     # Mutation
-    if (mutationChance > 0 & popSize > 0) {
+    if (mutationChance > 0 & popSize > 1) {
       verbose("  applying mutations... ");
       mutationCount = 0;
       for (object in 2:popSize) { # don't mutate the parent


### PR DESCRIPTION
Hi there, great package :) 
I think the requriements for a mutation should be `popSize > 1`, because of `2:popSize`. Currently if `popSize` is 1 it will generate the sequence `2 1`, which would mutate the parent and a non-existing child. 

Hope I am thinking the right way. 
greetings, Daniel