### PR TITLE
Fix verbose=TRUE reporting of mutationCount

### DIFF
--- a/R/GeneticAlg.int.R
+++ b/R/GeneticAlg.int.R
@@ -240,7 +240,7 @@ GeneticAlg.int <- function(genomeLen, codonMin, codonMax,
         
         population[object, ] = mutResult$newGenome;
         evalVals[object] = NA;
-        mutationCount = mutationCount + 1;
+        mutationCount = mutationCount + mutResult$numMutations;
       }
       verbose(paste(mutationCount, "mutations applied\n"));
     }


### PR DESCRIPTION
I previously opened an Issue showing that the verbose=TRUE report of the number of new mutations generated in an iteration (the mutationCount object) is insensitive to the value of mutationChance. This is because line 179 contains:

mutationCount = mutationCount + 1

Which specifies that the mutationCount increase by 1 each time the code loops through to mutate the next non-elite genome. However, this simply tracks the number of genomes subject [potentially] to mutation, which will be equal to popSize - elitism, regardless of the value of mutationChance.

A minor correction allows mutationCount to faithfully reflect the number of mutations applied in a given iteration (which should be ~ (popSize - elitism) * genomeLen * mutationChance.

I changed line 179 as follows, which corrects the reporting issue:
mutationCount = mutationCount + mutResult$numMutations